### PR TITLE
Use global pin for ldas-tools-framecpp

### DIFF
--- a/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
@@ -24,6 +24,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.8.____cpython.yaml
@@ -24,6 +24,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
@@ -24,6 +24,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -24,6 +24,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.23'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.10.____cpython.yaml
@@ -28,6 +28,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.8.____cpython.yaml
@@ -28,6 +28,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____cpython.yaml
@@ -28,6 +28,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
@@ -28,6 +28,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.23'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpython.yaml
@@ -24,6 +24,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.8.____cpython.yaml
@@ -24,6 +24,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpython.yaml
@@ -24,6 +24,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
@@ -24,6 +24,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 numpy:
 - '1.23'
 pin_run_as_build:

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
@@ -22,6 +22,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.8.____cpython.yaml
@@ -22,6 +22,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -22,6 +22,8 @@ gst_plugins_base:
 - '1.22'
 gstreamer:
 - '1.22'
+ldas_tools_framecpp:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -71,7 +71,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 
 
@@ -77,7 +77,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     /bin/bash
 else
 
-    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ build:
     - numpy
     # configure asks for it, but it is never actually used
     - liblalmetaio
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -53,7 +53,7 @@ requirements:
     - gst-python
     - gstlal >={{ gstlal_version }}
     - ldas-tools-al
-    - ldas-tools-framecpp >={{ framecpp_version }}
+    - ldas-tools-framecpp
     - libboost-headers
     - liblal >={{ lal_version }}
     - liblalmetaio >={{ lalmetaio_version }}


### PR DESCRIPTION
This PR patches this recipe to use the global pin for framecpp, allowing for coordinated migrations when a new major release of framecpp is created.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
